### PR TITLE
Add lightweight tree AI engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+*.db

--- a/branches.py
+++ b/branches.py
@@ -1,0 +1,50 @@
+import sqlite3
+import threading
+import collections
+import re
+
+_DB_PATH = 'branches.db'
+_conn = sqlite3.connect(_DB_PATH, check_same_thread=False)
+_conn.execute(
+    'CREATE TABLE IF NOT EXISTS stats (word TEXT PRIMARY KEY, count INTEGER)'
+)
+_lock = threading.Lock()
+
+
+def _update_stats(counter: collections.Counter) -> None:
+    with _lock:
+        for word, c in counter.items():
+            cur = _conn.execute(
+                'SELECT count FROM stats WHERE word=?', (word,)
+            )
+            row = cur.fetchone()
+            if row:
+                _conn.execute(
+                    'UPDATE stats SET count=? WHERE word=?',
+                    (row[0] + c, word),
+                )
+            else:
+                _conn.execute(
+                    'INSERT INTO stats(word, count) VALUES(?, ?)',
+                    (word, c),
+                )
+        _conn.commit()
+
+
+def learn(text: str) -> None:
+    tokens = re.findall(r"\w+", text.lower())
+    counter = collections.Counter(tokens)
+    _update_stats(counter)
+
+
+def learn_async(text: str) -> None:
+    thread = threading.Thread(target=learn, args=(text,), daemon=True)
+    thread.start()
+
+
+def top_words(limit: int = 10) -> list[str]:
+    cur = _conn.execute(
+        'SELECT word FROM stats ORDER BY count DESC LIMIT ?',
+        (limit,),
+    )
+    return [row[0] for row in cur.fetchall()]

--- a/roots.py
+++ b/roots.py
@@ -1,0 +1,27 @@
+import sqlite3
+import threading
+
+_DB_PATH = 'roots.db'
+_conn = sqlite3.connect(_DB_PATH, check_same_thread=False)
+_conn.execute(
+    'CREATE TABLE IF NOT EXISTS searches (word TEXT, snippet TEXT)'
+)
+_lock = threading.Lock()
+
+
+def store(word: str, snippet: str) -> None:
+    """Persist search snippet for a word."""
+    with _lock:
+        _conn.execute(
+            'INSERT INTO searches(word, snippet) VALUES(?, ?)',
+            (word, snippet),
+        )
+        _conn.commit()
+
+
+def get_memory(word: str) -> list[str]:
+    """Retrieve all snippets previously stored for a word."""
+    cur = _conn.execute(
+        'SELECT snippet FROM searches WHERE word=?', (word,)
+    )
+    return [row[0] for row in cur.fetchall()]

--- a/test_tree.py
+++ b/test_tree.py
@@ -1,0 +1,15 @@
+import tree
+
+
+def dummy_search(word: str) -> str:
+    return f"snippet {word}"
+
+
+def test_respond(monkeypatch):
+    monkeypatch.setattr(tree, 'search', dummy_search)
+    reply = tree.respond('meaning of life')
+    lines = [line for line in reply.strip().split('\n') if line]
+    assert len(lines) == 2
+    for line in lines:
+        words = line.split()
+        assert 4 <= len(words) <= 8

--- a/tree.py
+++ b/tree.py
@@ -1,0 +1,116 @@
+"""tree - true recursive echo engine."""
+
+import math
+import random
+import re
+from typing import List
+
+import requests
+
+from roots import store, get_memory
+from branches import learn_async, top_words
+
+
+def entropy(word: str) -> float:
+    counts = {ch: word.count(ch) for ch in set(word)}
+    total = len(word)
+    return -sum((c / total) * math.log2(c / total) for c in counts.values())
+
+
+def score(word: str) -> float:
+    return entropy(word) * len(set(word))
+
+
+def select_keywords(text: str) -> List[str]:
+    tokens = re.findall(r"\w+", text.lower())
+    unique = list(dict.fromkeys(tokens))
+    scored = sorted(
+        ((w, score(w)) for w in unique), key=lambda x: x[1], reverse=True
+    )
+    n = min(max(4, len(scored)), 6)
+    return [w for w, _ in scored[:n]]
+
+
+def search(word: str) -> str:
+    url = "https://api.duckduckgo.com/"
+    params = {
+        "q": word,
+        "format": "json",
+        "no_redirect": "1",
+        "no_html": "1",
+    }
+    try:
+        resp = requests.get(url, params=params, timeout=5)
+        data = resp.json()
+        snippet = (
+            data.get("Abstract")
+            or data.get("AbstractText")
+            or data.get("Definition")
+            or data.get("Heading")
+            or ""
+        )
+    except Exception:
+        snippet = ""
+    store(word, snippet)
+    return snippet
+
+
+def build_context(keywords: List[str], snippets: List[str]) -> str:
+    layer1 = " ".join(keywords)
+    layer2 = " ".join(snippets)
+    memory = []
+    for w in keywords:
+        memory.extend(get_memory(w))
+    layer3 = " ".join(memory)
+    layer4 = " ".join(top_words())
+    context = " ".join([layer1, layer2, layer3, layer4])
+    return context[:2048]
+
+
+def format_sentence(words: List[str]) -> str:
+    if not words:
+        return ""
+    sentence = " ".join(words)
+    return sentence.capitalize() + "."
+
+
+def make_sentence(
+    pool: List[str], user_words: set[str], max_user_words: int
+) -> str:
+    n = random.randint(4, 8)
+    random.shuffle(pool)
+    chosen: List[str] = []
+    user_count = 0
+    for w in pool:
+        if w in user_words:
+            if user_count >= max_user_words:
+                continue
+            user_count += 1
+        chosen.append(w)
+        if len(chosen) >= n:
+            break
+    filler = ["resonant", "echo", "branch", "root", "flow", "light"]
+    while len(chosen) < n:
+        chosen.append(random.choice(filler))
+    return format_sentence(chosen)
+
+
+def respond(message: str) -> str:
+    keywords = select_keywords(message)
+    snippets = [search(w) for w in keywords]
+    context = build_context(keywords, snippets)
+    learn_async(context)
+    user_words = set(re.findall(r"\w+", message.lower()))
+    pool = [w for w in re.findall(r"\w+", context.lower()) if w]
+    first = make_sentence(pool, user_words, 1)
+    second = make_sentence(pool, user_words, 0)
+    return f"{first}\n{second}"
+
+
+if __name__ == "__main__":
+    try:
+        while True:
+            msg = input(">> ")
+            print(respond(msg))
+    except (EOFError, KeyboardInterrupt):
+        pass


### PR DESCRIPTION
## Summary
- implement `tree` module for generating responses via entropy-ranked keywords and web snippets
- persist search snippets in SQLite `roots` memory and update stats asynchronously in `branches`
- add basic test verifying two-sentence structure

## Testing
- `flake8 branches.py roots.py tree.py test_tree.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba175d24b48329861bde48711f94ec