### PR TITLE
Use shared worker queue for branch learning

### DIFF
--- a/branches.py
+++ b/branches.py
@@ -1,23 +1,48 @@
-from __future__ import annotations
-
 """Learning tendrils for the tree engine.
 
-This module performs asynchronous persistence of search windows.  Each call to
-:func:`learn` sprouts a background thread that commits the gathered context to
-:mod:`roots` without blocking the caller.
+This module performs asynchronous persistence of search windows.  Instead of
+spawning a new thread for every :func:`learn` call, tasks are queued and
+consumed by a small pool of worker threads.  This keeps the number of threads
+bounded while still avoiding blocking the caller.
 """
 
+from __future__ import annotations
+
+import queue
 import threading
-from typing import Iterable
+from typing import Iterable, Tuple
 
 import roots
+
+# Fixed number of background workers processing tasks from ``_TASKS``.
+WORKER_LIMIT = 1
+_TASKS: "queue.Queue[Tuple[Iterable[str], str]]" = queue.Queue()
+
+
+def _worker() -> None:
+    """Consume queued learn tasks one at a time."""
+    while True:
+        words, context = _TASKS.get()
+        try:
+            for w in words:
+                roots.add_memory(w, context)
+        finally:
+            _TASKS.task_done()
+
+
+# Start the pool of worker threads on module import.
+for i in range(WORKER_LIMIT):
+    threading.Thread(target=_worker, daemon=True, name=f"branches-worker-{i}").start()
 
 
 def learn(words: Iterable[str], context: str) -> None:
     """Asynchronously record *words* with the given *context* window."""
 
-    def task() -> None:
-        for w in words:
-            roots.add_memory(w, context)
+    # Store a concrete sequence in the queue so generators remain valid.
+    _TASKS.put((list(words), context))
 
-    threading.Thread(target=task, daemon=True).start()
+
+def wait() -> None:
+    """Block until all queued learning tasks are processed."""
+
+    _TASKS.join()

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -1,0 +1,24 @@
+import pathlib
+import threading
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import branches
+
+
+def _count_workers() -> int:
+    return len([t for t in threading.enumerate() if t.name.startswith("branches-worker")])
+
+
+def test_mass_learn_does_not_spawn_extra_threads() -> None:
+    # Initial number of worker threads should match the configured limit.
+    assert _count_workers() == branches.WORKER_LIMIT
+
+    # Flood the system with learn requests.
+    for _ in range(200):
+        branches.learn(["alpha", "beta"], "ctx")
+
+    # Wait for all tasks to be processed before checking the count again.
+    branches.wait()
+
+    assert _count_workers() == branches.WORKER_LIMIT


### PR DESCRIPTION
## Summary
- Refactor `branches.learn` to enqueue tasks for a single worker thread
- Add helper to wait for queued tasks and expose worker limit
- Add tests simulating heavy `learn` usage to ensure no extra threads are created

## Testing
- `python -m ruff check branches.py tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba24f76d64832996b59aa12a26d4a6