### PR TITLE
Add Telegram bot with mocked test

### DIFF
--- a/ground.py
+++ b/ground.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+import os
+import signal
+
+from telegram import Update
+from telegram.ext import CallbackContext, Filters, MessageHandler, Updater
+
+import tree
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def handle_message(update: Update, context: CallbackContext) -> None:
+    """Handle incoming messages by responding via ``tree.respond``."""
+    try:
+        text = update.message.text or ""
+        response = tree.respond(text)
+        update.message.reply_text(response)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("error handling message")
+
+
+def main() -> None:
+    """Run the Telegram bot."""
+    token = os.environ.get("TELEGRAM_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_TOKEN not set")
+
+    updater = Updater(token, use_context=True)
+    dispatcher = updater.dispatcher
+    dispatcher.add_handler(
+        MessageHandler(Filters.text & ~Filters.command, handle_message)
+    )
+
+    def _shutdown(signum, frame):
+        logger.info("shutting down")
+        updater.stop()
+        updater.is_idle = False
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, _shutdown)
+
+    updater.start_polling()
+    updater.idle()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()

--- a/tests/test_ground.py
+++ b/tests/test_ground.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import ground  # noqa: E402
+
+
+def test_message_triggers_tree_response():
+    update = MagicMock()
+    context = MagicMock()
+    update.message.text = "hello"
+
+    with patch.object(
+        ground.tree, "respond", return_value="hi"
+    ) as mock_respond:
+        ground.handle_message(update, context)
+
+    mock_respond.assert_called_once_with("hello")
+    update.message.reply_text.assert_called_once_with("hi")


### PR DESCRIPTION
## Summary
- add `ground.py` telegram bot that uses `tree.respond`
- handle errors and graceful shutdown
- test that incoming messages call `tree.respond`

## Testing
- `python -m flake8 ground.py tests/test_ground.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba25457da08329bdeb4ce588a04ca3