### PR TITLE
Add pruning and word index to roots

### DIFF
--- a/tests/test_roots.py
+++ b/tests/test_roots.py
@@ -1,0 +1,26 @@
+import sqlite3
+from pathlib import Path
+
+import roots
+
+
+def setup_module(module):
+    if Path("tree.sqlite").exists():
+        Path("tree.sqlite").unlink()
+    roots.initialize()
+
+
+def test_initialize_creates_word_index():
+    with sqlite3.connect(roots.DB_PATH) as db:
+        cur = db.execute("PRAGMA index_list(memory)")
+        indexes = [row[1] for row in cur.fetchall()]
+    assert "idx_memory_word" in indexes
+
+
+def test_prune_limits_records():
+    roots.MEMORY_LIMIT = 3
+    for i in range(5):
+        roots.add_memory(f"w{i}", "ctx")
+    rows = list(roots.recall(10))
+    assert len(rows) == 3
+    assert [w for w, _ in rows] == ["w4", "w3", "w2"]


### PR DESCRIPTION
## Summary
- index memories by word for faster lookup
- prune old memory entries to keep database small
- add tests for index creation and pruning behavior

## Testing
- `black --check roots.py tests/test_roots.py`
- `flake8 roots.py tests/test_roots.py`
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'telegram.vendor.ptb_urllib3.urllib3.packages.six.moves')*

------
https://chatgpt.com/codex/tasks/task_e_68ba28a75db883299319204d61aa0fd7