### PR TITLE
Add TF-IDF semantic memory and retrieval

### DIFF
--- a/ground.py
+++ b/ground.py
@@ -4,8 +4,11 @@ import logging
 import os
 import signal
 
-from telegram import Update
-from telegram.ext import CallbackContext, Filters, MessageHandler, Updater
+try:  # pragma: no cover - optional telegram dependency
+    from telegram import Update
+    from telegram.ext import CallbackContext, Filters, MessageHandler, Updater
+except Exception:  # pragma: no cover - used only when telegram is installed
+    Update = CallbackContext = Filters = MessageHandler = Updater = object
 
 import tree
 

--- a/roots.py
+++ b/roots.py
@@ -10,35 +10,99 @@ standard library so the engine can run on the humblest CPU.
 
 from contextlib import closing
 from pathlib import Path
+from collections import Counter
+import math
+import re
 import sqlite3
-from typing import Iterable, Tuple
+from typing import Iterable, List, Tuple
 
 DB_PATH = Path("tree.sqlite")
 
 
 def initialize() -> None:
-    """Ensure the sqlite database exists with the required table."""
+    """Ensure the sqlite database exists with the required tables."""
     with closing(sqlite3.connect(DB_PATH)) as db:
         db.execute(
             """
             CREATE TABLE IF NOT EXISTS memory (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                word TEXT,
+                words TEXT,
                 context TEXT,
                 created REAL DEFAULT (strftime('%s','now'))
+            )
+            """
+        )
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS word_df (
+                word TEXT PRIMARY KEY,
+                df INTEGER
+            )
+            """
+        )
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memory_tf (
+                memory_id INTEGER,
+                word TEXT,
+                weight REAL,
+                FOREIGN KEY(memory_id) REFERENCES memory(id)
             )
             """
         )
         db.commit()
 
 
-def add_memory(word: str, context: str) -> None:
-    """Persist a searched *word* with its *context* window."""
+def _tokenize(text: str) -> List[str]:
+    """Split *text* into normalized word tokens."""
+    return re.findall(r"\w+", text.lower())
+
+
+def add_memory(words: Iterable[str], context: str) -> None:
+    """Persist *words* with their *context* window and TF-IDF weights."""
+    tokens = _tokenize(context)
+    if not tokens:
+        return
+
+    unique_words = " ".join(sorted(set(words)))
+
     with closing(sqlite3.connect(DB_PATH)) as db:
-        db.execute(
-            "INSERT INTO memory(word, context) VALUES (?, ?)",
-            (word, context[:2000]),
+        cur = db.execute(
+            "INSERT INTO memory(words, context) VALUES (?, ?)",
+            (unique_words, context[:2000]),
         )
+        memory_id = cur.lastrowid
+
+        counts = Counter(tokens)
+        total_terms = sum(counts.values())
+
+        # Update document frequencies for words appearing in this context
+        for w in counts:
+            db.execute(
+                "INSERT INTO word_df(word, df) VALUES(?, 1) "
+                "ON CONFLICT(word) DO UPDATE SET df = df + 1",
+                (w,),
+            )
+
+        # Total number of documents including the one just inserted
+        total_docs = db.execute(
+            "SELECT COUNT(*) FROM memory"
+        ).fetchone()[0]
+
+        for w, c in counts.items():
+            df = db.execute(
+                "SELECT df FROM word_df WHERE word = ?",
+                (w,),
+            ).fetchone()[0]
+            tf = c / total_terms
+            idf = math.log(total_docs / df) + 1.0
+            weight = tf * idf
+            db.execute(
+                "INSERT INTO memory_tf(memory_id, word, weight) "
+                "VALUES (?, ?, ?)",
+                (memory_id, w, weight),
+            )
+
         db.commit()
 
 
@@ -46,10 +110,35 @@ def recall(limit: int = 5) -> Iterable[Tuple[str, str]]:
     """Return the most recent memories for inspection."""
     with closing(sqlite3.connect(DB_PATH)) as db:
         cur = db.execute(
-            "SELECT word, context FROM memory ORDER BY id DESC LIMIT ?",
+            "SELECT words, context FROM memory ORDER BY id DESC LIMIT ?",
             (limit,),
         )
         return cur.fetchall()
+
+
+def recall_semantic(
+    query_words: Iterable[str], limit: int = 5
+) -> Iterable[Tuple[str, str]]:
+    """Return memories ranked by TF-IDF relevance to *query_words*."""
+    words = [w.lower() for w in query_words]
+    if not words:
+        return []
+
+    placeholders = ",".join("?" * len(words))
+    with closing(sqlite3.connect(DB_PATH)) as db:
+        cur = db.execute(
+            f"""
+            SELECT m.words, m.context, SUM(t.weight) AS score
+            FROM memory m
+            JOIN memory_tf t ON m.id = t.memory_id
+            WHERE t.word IN ({placeholders})
+            GROUP BY m.id
+            ORDER BY score DESC
+            LIMIT ?
+            """,
+            (*words, limit),
+        )
+        return [(row[0], row[1]) for row in cur.fetchall()]
 
 
 # Create the database on import so roots exist immediately.

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -3,11 +3,17 @@ import threading
 import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-import branches
+import branches  # noqa: E402
 
 
 def _count_workers() -> int:
-    return len([t for t in threading.enumerate() if t.name.startswith("branches-worker")])
+    return len(
+        [
+            t
+            for t in threading.enumerate()
+            if t.name.startswith("branches-worker")
+        ]
+    )
 
 
 def test_mass_learn_does_not_spawn_extra_threads() -> None:

--- a/tests/test_roots.py
+++ b/tests/test_roots.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import roots  # noqa: E402
+
+
+def _reset_db():
+    if Path("tree.sqlite").exists():
+        Path("tree.sqlite").unlink()
+    roots.initialize()
+
+
+def test_recall_semantic_ranks_by_tfidf():
+    _reset_db()
+    roots.add_memory(["alpha"], "alpha beta")
+    roots.add_memory(["beta"], "beta beta beta")
+    roots.add_memory(["gamma"], "gamma delta")
+
+    results = roots.recall_semantic(["beta"], limit=2)
+    contexts = [r[1] for r in results]
+    assert contexts[0] == "beta beta beta"
+    assert contexts[1] == "alpha beta"

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -29,7 +29,7 @@ def test_responses_evolve(monkeypatch):
     monkeypatch.setattr(
         tree.branches,
         "learn",
-        lambda w, c: [roots.add_memory(k, c) for k in w],
+        lambda w, c: roots.add_memory(w, c),
     )
 
     random.seed(0)

--- a/tree.py
+++ b/tree.py
@@ -120,8 +120,14 @@ def _update_ngram_with_text(text: str) -> None:
         NGRAMS[a][b] += 1
 
 
-def _update_ngrams_from_roots(limit: int = 100) -> None:
-    for _, ctx in roots.recall(limit):
+def _update_ngrams_from_roots(
+    limit: int = 100, query: Iterable[str] | None = None
+) -> None:
+    """Prime NGRAMS using stored roots, optionally filtered by *query*."""
+    memories = (
+        roots.recall_semantic(query, limit) if query else roots.recall(limit)
+    )
+    for _, ctx in memories:
         _update_ngram_with_text(ctx)
 
 
@@ -269,9 +275,8 @@ def respond(message: str) -> str:
     if not message.strip():
         return "Emptiness speaks. Silence responds."
 
-    _update_ngrams_from_roots()
-
     keys = _keywords(message)
+    _update_ngrams_from_roots(query=keys)
     ctx = _context(keys)
 
     # Fallback if context is poor quality


### PR DESCRIPTION
## Summary
- compute TF-IDF weights for stored contexts and expose a semantic recall API
- update branches worker and response pipeline to leverage TF-IDF memory
- add regression tests for semantic ranking and handle optional Telegram dependency

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba28d195848329bcca7ad33a0a22ca