### PR TITLE
Improve tree engine multilingual learning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+tree.sqlite
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
## Summary
- mix user tokens into generated text based on context quality
- detect conversation language and fetch web snippets with matching headers
- persist each dialogue and wait for learning to complete; split replies across lines
- ignore generated `tree.sqlite` database

## Testing
- `flake8 && echo 'flake8 passed'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba3305f9348329b079c44f355e3edc