### PR TITLE
Improve Tree engine language awareness and learning

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -25,7 +25,7 @@ def test_responses_evolve(monkeypatch):
         quality_score=1.0,
     )
 
-    monkeypatch.setattr(tree, "_context", lambda _: fixed_ctx)
+    monkeypatch.setattr(tree, "_context", lambda w, lang='en-us': fixed_ctx)
     monkeypatch.setattr(
         tree.branches,
         "learn",


### PR DESCRIPTION
## Summary
- detect user language and query web in same language
- blend source words into responses for conversational style
- wait for background learning to finish after each message

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba3305f9348329b079c44f355e3edc