### PR TITLE
Randomize token selection to avoid repetitive country lists

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -341,6 +341,7 @@ def _select(
 
     src_vec = _source_vector(source)
     if not src_vec:
+        random.shuffle(tokens)
         return tokens[:limit]
 
     graded = []
@@ -366,21 +367,16 @@ def _compose(
     if not candidates:
         return "Silence echoes."
 
-    n = random.randint(min_words, min(max_words, len(candidates)))
-    chosen = candidates[:n]
+    max_n = min(max_words, len(candidates))
+    min_n = min(min_words, max_n)
+    n = random.randint(min_n, max_n)
+    chosen = random.sample(candidates, n)
 
-    # Simple sentence structure improvements
-    sentence = " ".join(chosen)
-
-    # Add some natural flow
     if len(chosen) > 4:
-        # Insert occasional conjunctions for longer sentences
         mid_point = len(chosen) // 2
         chosen.insert(mid_point, random.choice(["and", "through", "within"]))
-        sentence = " ".join(chosen)
 
-    # Ensure proper capitalization and punctuation
-    sentence = sentence.capitalize()
+    sentence = " ".join(chosen).capitalize()
     if not sentence.endswith("."):
         sentence += "."
 


### PR DESCRIPTION
## Summary
- shuffle fallback token list when no semantic vectors are available
- sample and shuffle candidate words before composing responses to reduce alphabetical bias

## Testing
- `flake8`
- `black --check tree.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba352295c0832996e149e07604e129