### PR TITLE
Shuffle fallback selection to avoid repetitive country lists

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -37,3 +37,24 @@ def test_responses_evolve(monkeypatch):
     random.seed(0)
     second = tree.respond("alpha beta")
     assert first != second
+
+
+def test_select_random_fallback():
+    tree.NGRAMS.clear()
+    tokens = [
+        "africa",
+        "arabia",
+        "argentina",
+        "australia",
+        "austria",
+        "belgium",
+    ]
+    random.seed(0)
+    result = tree._select(tokens, ["hello"], 0.4, limit=5)
+    assert result == [
+        "austria",
+        "argentina",
+        "arabia",
+        "africa",
+        "belgium",
+    ]

--- a/tree.py
+++ b/tree.py
@@ -116,6 +116,7 @@ STOPWORDS = {
     "first",
     "could",
     "any",
+    "all",
 }
 
 
@@ -285,7 +286,8 @@ def _context(words: Iterable[str]) -> Context:
         if len(t) > 2 and not t.isdigit() and t not in STOPWORDS  # noqa: E501
     ]
 
-    unique = sorted(set(filtered_tokens))
+    # Preserve the order of appearance for more organic selection
+    unique = list(dict.fromkeys(filtered_tokens))
 
     # Calculate quality score based on diversity and length
     quality_score = len(unique) / max(len(tokens), 1) if tokens else 0
@@ -341,6 +343,7 @@ def _select(
 
     src_vec = _source_vector(source)
     if not src_vec:
+        random.shuffle(tokens)
         return tokens[:limit]
 
     graded = []


### PR DESCRIPTION
## Summary
- avoid ordered country lists by shuffling fallback tokens
- track original token order in contexts and ignore generic word "all"
- test random fallback behaviour

## Testing
- `black tree.py tests/test_tree.py`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba352295c0832996e149e07604e129