### PR TITLE
Filter short and stop words in recall

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -58,3 +58,23 @@ def test_select_random_fallback():
         "africa",
         "belgium",
     ]
+
+
+def test_short_query_no_recall(monkeypatch):
+    def boom(limit):  # pragma: no cover - should not be called
+        raise AssertionError(
+            "roots.recall should not be invoked for short words"
+        )
+
+    monkeypatch.setattr(roots, "recall", boom)
+    assert tree._recall_fragment("you") is None
+
+
+def test_stopword_no_recall(monkeypatch):
+    def boom(limit):  # pragma: no cover - should not be called
+        raise AssertionError(
+            "roots.recall should not be invoked for stopwords"
+        )
+
+    monkeypatch.setattr(roots, "recall", boom)
+    assert tree._recall_fragment("the") is None

--- a/tree.py
+++ b/tree.py
@@ -242,7 +242,11 @@ def _hash_ngrams(text: str, n: int = 3) -> set[int]:
 
 def _recall_fragment(word: str, limit: int = 50) -> str | None:
     """Find a relevant context for *word* from stored roots."""
-    target = _hash_ngrams(word)
+    word_l = word.lower()
+    if len(word_l) < 4 or word_l in STOPWORDS:
+        return None
+
+    target = _hash_ngrams(word_l)
     if not target:
         return None
 
@@ -255,7 +259,9 @@ def _recall_fragment(word: str, limit: int = 50) -> str | None:
         score = len(target & grams) / len(target)
         if score > best_score:
             best_score, best_ctx = score, ctx
-    if best_ctx and best_score > 0.1:
+
+    threshold = 0.5 if len(word_l) <= 5 else 0.1
+    if best_ctx and best_score > threshold:
         return best_ctx[:600]
     return None
 


### PR DESCRIPTION
## Summary
- ignore stopwords and short tokens during fragment recall
- raise match threshold for brief queries
- test that short words and stopwords yield no recall

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba545cd25c8329aae203cdd312e068